### PR TITLE
Feature/logout modal

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -38,6 +38,9 @@
     "alreadyExistText": "Already have an account? ",
     "click": "Click here! ",
     "continueWithGoogle": "Continue with Google",
-    "continue": "Continue"
+    "continue": "Continue",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "logoutText": "Are you sure you want to log out?"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -13,6 +13,7 @@
     "logIn": "Log In",
     "logOut": "Log Out",
     "loginTitle": "Login",
+    "logoutTitle": "Logout",
     "loginText": "Please, login into your medical account",
     "registrationTitle": "Registration",
     "registrationText": "Please, create your medical account and become a member",

--- a/src/components/ExamapleForm/index.tsx
+++ b/src/components/ExamapleForm/index.tsx
@@ -1,7 +1,7 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 import { Inputs } from './types';
-import { Form } from './style';
+import Form from './style';
 
 export default function ExampleForm() {
   const {

--- a/src/components/ExampleComponent/index.tsx
+++ b/src/components/ExampleComponent/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { ExampleButton } from './style';
+import ExampleButton from './style';
 import { useToggle } from './exampleComponentHooks';
 import { useTranslation } from 'react-i18next';
 import { useLanguageSwitcher } from './exampleComponentHooks';

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { CancelButton, SendButton, ModalButtonsWrapper, ModalContainer, ModalContent, ModalOverlay, Title } from '../Modal/styles';
+
+interface IModal {
+    confirmText: string;
+    cancelTest: string;
+    title: string;
+}
+
+function LogoutModal({confirmText, cancelTest, title}: IModal) {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleSubmit = () => {
+    // TODO: implement logout logic here
+    setShowModal(false);
+  };
+
+  return (
+    <>
+      <button onClick={() => setShowModal(true)}>Logout</button>
+      {showModal && (
+        <ModalOverlay>
+            <ModalContainer>
+                <ModalContent>
+                    <Title>{title}</Title>
+                    <ModalButtonsWrapper>
+                        <CancelButton 
+                            disabled={false}
+                            type='button'
+                            value={cancelTest}
+                            onClick={() => setShowModal(false)}/>
+                        <SendButton 
+                            disabled={false}
+                            type='submit'
+                            value={confirmText}
+                            onClick={handleSubmit}/>
+                    </ModalButtonsWrapper>
+                </ModalContent>
+            </ModalContainer>
+        </ModalOverlay>
+      )}
+    </>
+  );
+}
+
+export default LogoutModal;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,23 +1,25 @@
 import React, { useState } from 'react';
-import { CancelButton, SendButton, ModalButtonsWrapper, ModalContainer, ModalContent, ModalOverlay, Title } from '../Modal/styles';
+import { CancelButton, SendButton, ModalButtonsWrapper, ModalContainer, ModalContent, ModalOverlay, Title, ModalTrigger } from '../Modal/styles';
 
 interface IModal {
     confirmText: string;
     cancelTest: string;
     title: string;
+    handleSubmitModal: Function;
+    modalTriggerText: string;
 }
 
-function LogoutModal({confirmText, cancelTest, title}: IModal) {
+function LogoutModal({confirmText, cancelTest, title, handleSubmitModal, modalTriggerText}: IModal) {
   const [showModal, setShowModal] = useState(false);
 
   const handleSubmit = () => {
-    // TODO: implement logout logic here
+    handleSubmitModal();
     setShowModal(false);
   };
 
   return (
     <>
-      <button onClick={() => setShowModal(true)}>Logout</button>
+      <ModalTrigger onClick={() => setShowModal(true)}>{modalTriggerText}</ModalTrigger>
       {showModal && (
         <ModalOverlay>
             <ModalContainer>

--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -107,3 +107,6 @@ export const Title = styled.h2`
   font-family: ${FONT_ROBOTO};
   text-align: center;
 `;
+
+export const ModalTrigger = styled.button`
+`

--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -1,0 +1,109 @@
+import styled from "styled-components";
+import {
+  BLACK, CORNFLOWER_BLUE,
+  GRAY_SHADOW,
+  NAVY_BLUE,
+  PINK_SWAN,
+  WHISPER,
+  WHITE
+} from '@constants/colors';
+import { SMALL_FONT_SIZE } from '@constants/fontSizes';
+import { FONT_ROBOTO } from '@constants/fonts';
+
+export const SendButton = styled.input`
+  :disabled {
+    background: ${PINK_SWAN}; 
+    color: ${WHITE}; 
+  }
+  display: flex;
+  margin-right: auto;
+  margin-left: auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-family: ${FONT_ROBOTO};
+  border: none;
+  height: 55px;
+  width: 45%;
+  margin-top: 20px;
+  line-height: 22px;
+  color: ${WHITE}; 
+  font-size: ${SMALL_FONT_SIZE};
+  font-weight: bold;
+  background: -webkit-linear-gradient(${NAVY_BLUE}, ${CORNFLOWER_BLUE});
+`;
+
+export const CancelButton = styled.input`
+  display: flex;
+  margin-right: auto;
+  margin-left: auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-family: ${FONT_ROBOTO};
+  border: none;
+  height: 55px;
+  width: 45%;
+  margin-top: 20px;
+  line-height: 22px;
+  color: ${WHITE}; 
+  font-size: ${SMALL_FONT_SIZE};
+  font-weight: bold;
+  background: ${PINK_SWAN};
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export const ModalContainer = styled.div`
+  z-index: 1000;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  margin-left: auto;
+  margin-right: auto;
+  align-items: center;
+  justify-content: center;
+  font-family: ${FONT_ROBOTO};
+  border-radius: 8px;
+  border: 2px solid ${WHISPER};
+  height: fit-content;
+  width: fit-content;
+  padding: 32px;
+  background-color: ${WHITE}; 
+  color: ${BLACK}; 
+  font-size: ${SMALL_FONT_SIZE};
+  font-weight: bold;
+  transition: all 0.2s ease-in-out;
+`
+
+export const ModalContent = styled.div`
+  height: fit-content;
+  width: fit-content;
+`
+
+export const ModalButtonsWrapper = styled.div`
+  display: flex;
+  width: max-width;
+`
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: ${GRAY_SHADOW};
+`
+
+export const Title = styled.h2`
+  color: ${BLACK}; 
+  margin-bottom: 10px;
+  font-family: ${FONT_ROBOTO};
+  text-align: center;
+`;

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -50,3 +50,7 @@ export const SNUFF = "#0000FF00";
  * @deprecated
  */
 export const RED = "#FF0000FF";
+/**
+ * @deprecated
+ */
+export const GRAY_SHADOW = '#66666666';

--- a/src/pages/auth/signUp/index.tsx
+++ b/src/pages/auth/signUp/index.tsx
@@ -2,11 +2,17 @@ import React from 'react';
 
 import Logo from '@components/Logo';
 import SignUpForm from '@components/Auth/SignUpForm';
+import LogoutModal from '@components/Modal';
+import { useTranslation } from 'react-i18next';
 
 const SignUp = () => {
+
+  const { t } = useTranslation();
   return (
     <>
       <Logo />
+      {/* test modal - delete later */}
+      <LogoutModal title={t("Auth.logoutText").toString()} confirmText={t("Auth.confirm").toString()}  cancelTest={t("Auth.cancel").toString()} />
       <SignUpForm/>
     </>
   );

--- a/src/pages/auth/signUp/index.tsx
+++ b/src/pages/auth/signUp/index.tsx
@@ -2,17 +2,12 @@ import React from 'react';
 
 import Logo from '@components/Logo';
 import SignUpForm from '@components/Auth/SignUpForm';
-import LogoutModal from '@components/Modal';
 import { useTranslation } from 'react-i18next';
 
 const SignUp = () => {
-
-  const { t } = useTranslation();
   return (
     <>
       <Logo />
-      {/* test modal - delete later */}
-      <LogoutModal title={t("Auth.logoutText").toString()} confirmText={t("Auth.confirm").toString()}  cancelTest={t("Auth.cancel").toString()} />
       <SignUpForm/>
     </>
   );


### PR DESCRIPTION
**Description changes:**
- Make UI template for modals
- Make UI for logout modal
- When modal is open, the rest of page is blocked
- Modal can be closed with click "Cancel" or "Confrim"
- Confirm button accept onConfirm fucntion and then close modal
P.S.: logout button in testing stage, because it will appear only in dashboard.
## Issue ticket code (and/or) and link
> [Link to JIRA ticket](https://smartdc23.atlassian.net/browse/SMAR-39?atlOrigin=eyJpIjoiNTBlZjdkYjVmODRkNGZkNWI5YjVmOWYxNDA3N2NiOTMiLCJwIjoiaiJ9)

### General
- [ ] Assigned myself to the PR
- [ ] Assigned the appropriate labels to the PR
- [ ] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [ ] Performed a self-review of my code
- [ ] Types for input and output parameters
- [ ] Don't have "any" on my code
- [ ] Used the try/catch pattern for error handling
- [ ] Don't have magic numbers
- [ ] Compare only with constants not with strings
- [ ] No ternary operator inside ternary operator
- [ ] Don't have commented code
- [ ] no links in the code, env links should be in env file (for example: server url), constant links (for example default avatar URL) should be in constant file.
- [ ] Used camelCase for variables and functions
- [ ] Date and time formats are on the constants
- [ ] Functions is public only if it's used outside the class
- [ ] No hardcoded values
- [ ] covered by tests
- [ ] check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend
- [ ] Components and business logic are separated
- [ ] Colors, Font Size, and Font Name is on the theme or in the constants
- [ ] No text in the components, use i18n approach
- [ ] No inline styles
- [ ] Imports are absolute
- [ ] Attach a screenshot if PR has visual changes.

**Logout button:**
![image](https://user-images.githubusercontent.com/72575014/230402773-2788b7ca-f2e9-4e68-b649-fd004ca83bad.png)

**Logout modal has shadow, which block the rest of page:**
![image](https://user-images.githubusercontent.com/72575014/230402892-32a06408-429f-4186-b8a8-1b5ee92ee27f.png)

