### PR TITLE
fix: add message for local doctor, if go to availability tab

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -159,7 +159,8 @@
     "saveSchedule": "Save schedule",
     "selectTimezone": "Time Zone:",
     "successfullySubmited": "Your schedule has been successfully updated!",
-    "calendar": "Calendar"
+    "calendar": "Calendar",
+    "localDoctorAvailability": "As Local doctor you work full-time work day and can't set your availability time!"
   },
   "BookAppointment": {
     "selectDoctorSpecialization": "Select doctor specialization",

--- a/src/components/Scheduler/LocalDoctorSceduler/index.tsx
+++ b/src/components/Scheduler/LocalDoctorSceduler/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { PATH } from '@router/index';
+import { BackToDashLink, Wrapper } from '@pages/notFound/styles';
+import { ReactComponent as ArrowLeft } from '@assets/arrowLeft.svg';
+import { useTranslation } from 'react-i18next';
+
+export default function LocalDoctorScheduler() {
+    const { t } = useTranslation();
+
+    return (
+        <Wrapper>
+            <p>{t('Calendar.localDoctorAvailability')}</p>
+            <BackToDashLink to={PATH.DASHBOARD}>
+            <ArrowLeft />
+            {t('Dashboard.backToDashboard')}
+            </BackToDashLink>
+        </Wrapper>
+  )
+}

--- a/src/components/Scheduler/LocalDoctorSceduler/index.tsx
+++ b/src/components/Scheduler/LocalDoctorSceduler/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { PATH } from '@router/index';
 import { BackToDashLink, Wrapper } from '@pages/notFound/styles';
 import { ReactComponent as ArrowLeft } from '@assets/arrowLeft.svg';
-import { useTranslation } from 'react-i18next';
 
 export default function LocalDoctorScheduler() {
     const { t } = useTranslation();
@@ -11,8 +11,8 @@ export default function LocalDoctorScheduler() {
         <Wrapper>
             <p>{t('Calendar.localDoctorAvailability')}</p>
             <BackToDashLink to={PATH.DASHBOARD}>
-            <ArrowLeft />
-            {t('Dashboard.backToDashboard')}
+                <ArrowLeft />
+                {t('Dashboard.backToDashboard')}
             </BackToDashLink>
         </Wrapper>
   )

--- a/src/constants/patient.ts
+++ b/src/constants/patient.ts
@@ -20,3 +20,5 @@ export const unknownGender = 'Unknown gender';
 export const unknownCity = 'Unknown city';
 export const unknownCountry = 'Unknown country';
 export const unknownAge = 'Unknown age';
+export const local = 'Local';
+export const remote = 'Remote';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -78,22 +78,6 @@ const AppRouter = () => {
           }
         />
         <Route
-          path={PATH.FORGOT_PASS}
-          element={
-            <ProtectedRoute allowedRoles={['Remote', 'Local']}>
-              <ForgotPassword />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path={PATH.CONFIRM}
-          element={
-            <ProtectedRoute allowedRoles={['Remote', 'Local']}>
-              <Confirmation />
-            </ProtectedRoute>
-          }
-        />
-        <Route
           path={PATH.EDIT_DOCTOR_PROFILE}
           element={
             <ProtectedRoute allowedRoles={['Remote', 'Local']}>

--- a/src/router/protected-route.tsx
+++ b/src/router/protected-route.tsx
@@ -4,6 +4,9 @@ import Spinner from '@components/Loaders/Spinner';
 import { Stack } from '@mui/system';
 import { authApi } from 'services/AuthService';
 import cookie from 'utils/functions/cookies';
+import LocalDoctorScheduler from '@components/Scheduler/LocalDoctorSceduler';
+import { local } from '@constants/patient';
+import { PATH } from '.';
 
 interface ProtectedRoutesProps {
   children: any;
@@ -21,6 +24,10 @@ const ProtectedRoute = ({ children, allowedRoles }: ProtectedRoutesProps) => {
 
   if (isLoading) {
     return <Spinner />;
+  }
+
+  if (doctorRole === local && location.pathname === PATH.AVAILABILITY) {
+    return <LocalDoctorScheduler />;
   }
 
   if (!isLoggedIn || !allowedRoles.includes(doctorRole)) {


### PR DESCRIPTION
## Description changes:
• Fixed the return to login if Local doctor click on availability tab;
• If local doctor click availability tab - description message appears

## Issue ticket code (and/or) and link
> [Link to JIRA ticket](https://smartdc23.atlassian.net/browse/SMAR-147?atlOrigin=eyJpIjoiMTdiNjkzODlkZWU4NGY0OGExOWQ4MGNiOTM3NWM4YWIiLCJwIjoiaiJ9)

### General
- [x] Assigned myself to the PR
- [x] Assigned the appropriate labels to the PR
- [x] Assigned the appropriate reviewers to the PR
- [ ] Updated the documentation
- [x] Performed a self-review of my code
- [x] Don't have "any" on my code
- [x] Don't have magic numbers
- [x] Compare only with constants not with strings
- [x] No ternary operator inside ternary operator
- [x] Don't have commented code
- [x] All links in on ENV files
- [x] Used camelCase for variables and functions
- [x] Functions is public only if it's used outside the class
- [x] No hardcoded values
- [x] Check your commit messages meet the [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/).

### Frontend
- [x] Components and business logic are separated
- [x] Colors, Font Size, and Font Name is on the theme or in the constants
- [x] No text in the components, use i18n approach
- [x] No inline styles
- [x] Imports are absolute
- [x] Attach a screenshot if PR has visual changes.

### Screenshots
#### Message if local doctor goes to availability tab:
![image](https://github.com/ZenBit-Tech/WebWizards_fe/assets/72575014/78d1d7ec-deff-4a84-b1e6-10849be2b9c0)
